### PR TITLE
Move demo deployment to separate workflow

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,35 @@
+name: Deploy Demo to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-demo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+      - name: Install parent dependencies
+        run: npm install
+      - name: Build parent project
+        run: npm run build
+      - name: Install test-install dependencies
+        working-directory: ./test-install
+        run: npm install
+      - name: Build test-install
+        working-directory: ./test-install
+        run: npm run build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./test-install/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,37 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm run test
       - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  deploy-demo:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-      - name: Install parent dependencies
-        run: npm install
-      - name: Build parent project
-        run: npm run build
-      - name: Install test-install dependencies
-        working-directory: ./test-install
-        run: npm install
-      - name: Build test-install
-        working-directory: ./test-install
-        run: npm run build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./test-install/dist


### PR DESCRIPTION
Extracted the demo deployment job from publish.yml into a new deploy-demo.yml workflow. This separation clarifies responsibilities between publishing to npm and deploying the demo to GitHub Pages.